### PR TITLE
Users can add & edit categories when creating a new thread on the main chat and filter all chat messages by category.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.idea
+*-lock.json

--- a/README.md
+++ b/README.md
@@ -1,0 +1,50 @@
+# Residency Match
+
+See our [website](https://residencymatch.net/).
+
+## Local Development Setup
+
+Have npm installed.
+
+```shell
+resmatch/backend $ npm install
+resmatch/frontend $ npm install
+```
+
+Create the file `backend/.env`.
+
+```shell
+DATABASE_URL=postgresql://user:postgres@localhost:5432/resmatch?schema=public
+SECRET_KEY=[random_key]
+MAILGUN_API_KEY=[mailgun_api_key]
+FRONTEND_URL=http://localhost:5173/
+GOOGLE_CLIENT_ID=[google_client_id]
+GOOGLE_CLIENT_SECRET=[google_client_secret]
+```
+
+Create the file `frontend/.env.local`.
+
+```shell
+VITE_API_URL=http://localhost:3000/
+```
+
+## Running the application
+
+Open two terminals, one for each process.
+
+```shell
+resmatch/backend $ npm start
+resmatch/frontend $ npm run dev
+```
+
+In the browser, navigate to http://localhost:5173/, or the url you defined in
+the backend env file.
+
+## Migrating the database
+
+- Make sure postgres is up and running.
+- Navigate to `backend/prisma/schema.prisma`.
+- Update schemas as needed.
+- Run `npx prisma migrate dev --name [name]`, where name is used for the output
+  migration script file name.
+- You should also be able to deploy it with `npx prisma migrate deploy`. 

--- a/backend/prisma/migrations/20240929231809_comment_category/migration.sql
+++ b/backend/prisma/migrations/20240929231809_comment_category/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "CommentCategory" AS ENUM ('VENT', 'ADVICE', 'SERIOUS_QUESTION', 'HAPPY');
+
+-- AlterTable
+ALTER TABLE "Comment" ADD COLUMN     "category" "CommentCategory";

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -364,10 +364,18 @@ model Comment {
   CityUserInput         CityUserInput?       @relation(fields: [cityUserInputId], references: [id])
   cityUserInputId       Int?
   upvotedUsers          User[]               @relation("upvotedComments")
+  category              CommentCategory?      
 
   @@index([parentId])
   @@index([userId])
   @@index(fields: [userId, parentId])
+}
+
+enum CommentCategory {
+  VENT
+  ADVICE 
+  SERIOUS_QUESTION
+  HAPPY
 }
 
 model RankList {

--- a/backend/src/routers/commentRouter.ts
+++ b/backend/src/routers/commentRouter.ts
@@ -1,6 +1,6 @@
 import express from "express";
+import {verifyToken} from "../middleware/authMiddleware.js";
 import prisma from "../prismaClient.js";
-import { verifyToken } from "../middleware/authMiddleware.js";
 
 const commentRouter = express.Router();
 
@@ -23,18 +23,18 @@ commentRouter.post("/", verifyToken, async (req, res) => {
     res.status(201).json(newComment);
   } catch (error) {
     console.error("Error creating comment:", error);
-    res.status(500).json({ error: "Internal Server Error" });
+    res.status(500).json({error: "Internal Server Error"});
   }
 });
 
 // Get a single comment by ID
 commentRouter.get("/:id", async (req, res) => {
-  const { id } = req.params;
+  const {id} = req.params;
 
   try {
     // Fetch the comment with the user and replies included, ordered by createdAt
     const comment = await prisma.comment.findUnique({
-      where: { id: Number(id) },
+      where: {id: Number(id)},
       include: {
         user: true, // Include the user information
         replies: {
@@ -49,7 +49,7 @@ commentRouter.get("/:id", async (req, res) => {
     });
 
     if (!comment) {
-      return res.status(404).json({ error: "Comment not found" });
+      return res.status(404).json({error: "Comment not found"});
     }
 
     // Check if the comment is not linked, if so, remove the user data
@@ -60,36 +60,37 @@ commentRouter.get("/:id", async (req, res) => {
     res.json(comment);
   } catch (error) {
     console.error("Error fetching comment:", error);
-    res.status(500).json({ error: "Internal Server Error" });
+    res.status(500).json({error: "Internal Server Error"});
   }
 });
 
+
 // Update a comment by ID
 commentRouter.put("/:id", verifyToken, async (req, res) => {
-  const { id } = req.params;
-  const { content } = req.body;
+  const {id} = req.params;
+  const {content, category} = req.body;
 
   // Fetch the item to verify ownership
   const item = await prisma.comment.findUnique({
-    where: { id: Number(req.params.id) }, // Assuming `id` is the primary key
-    select: { userId: true }, // Adjust based on your model's fields
+    where: {id: Number(req.params.id)}, // Assuming `id` is the primary key
+    select: {userId: true}, // Adjust based on your model's fields
   });
 
   if (!item) {
-    return res.status(404).json({ error: `comment not found` });
+    return res.status(404).json({error: `comment not found`});
   }
 
   // Check if the current user is the owner of the item
   if (item.userId !== req.user.id) {
     return res
       .status(403)
-      .json({ error: "You do not have permission to update this item" });
+      .json({error: "You do not have permission to update this item"});
   }
 
   try {
     const updatedComment = await prisma.comment.update({
-      where: { id: Number(id) },
-      data: { content },
+      where: {id: Number(id)},
+      data: {content, category},
     });
 
     res.json(updatedComment);
@@ -97,59 +98,62 @@ commentRouter.put("/:id", verifyToken, async (req, res) => {
     console.error("Error updating comment:", error);
 
     if (error.code === "P2025") {
-      return res.status(404).json({ error: "Comment not found" });
+      return res.status(404).json({error: "Comment not found"});
     }
 
-    res.status(500).json({ error: "Internal Server Error" });
+    res.status(500).json({error: "Internal Server Error"});
   }
 });
 
 // Delete a comment by ID
 commentRouter.delete("/:id", verifyToken, async (req, res) => {
-  const { id } = req.params;
+  const {id} = req.params;
 
   // Fetch the item to verify ownership
   const item = await prisma.comment.findUnique({
-    where: { id: Number(req.params.id) }, // Assuming `id` is the primary key
-    select: { userId: true }, // Adjust based on your model's fields
+    where: {id: Number(req.params.id)}, // Assuming `id` is the primary key
+    select: {userId: true}, // Adjust based on your model's fields
   });
 
   if (!item) {
-    return res.status(404).json({ error: `comment not found` });
+    return res.status(404).json({error: `comment not found`});
   }
 
   // Check if the current user is the owner of the item
   if (item.userId !== req.user.id) {
     return res
       .status(403)
-      .json({ error: "You do not have permission to update this item" });
+      .json({error: "You do not have permission to update this item"});
   }
 
   try {
     await prisma.comment.delete({
-      where: { id: Number(id) },
+      where: {id: Number(id)},
     });
 
-    res.json({ message: `Comment with ID: ${id} deleted` });
+    res.json({message: `Comment with ID: ${id} deleted`});
   } catch (error) {
     console.error("Error deleting comment:", error);
 
     if (error.code === "P2025") {
-      return res.status(404).json({ error: "Comment not found" });
+      return res.status(404).json({error: "Comment not found"});
     }
 
-    res.status(500).json({ error: "Internal Server Error" });
+    res.status(500).json({error: "Internal Server Error"});
   }
 });
 
 commentRouter.post("/search", async (req, res) => {
-  const { pageNum = 1, ...queryParams } = req.body;
+  const {pageNum = 1, selectedCommentCategories, ...queryParams} = req.body;
   const PAGE_SIZE = 10; // Example page size
 
   try {
     // Construct the where clause dynamically using req.body
     const whereClause = {
       parentId: null,
+      category: selectedCommentCategories.length > 0 ? {
+        in: selectedCommentCategories,  // 'in' operator to find matching categories
+      } : undefined,
       ...queryParams, // Spread all properties from req.body
     };
 
@@ -184,10 +188,10 @@ commentRouter.post("/search", async (req, res) => {
       return comment;
     });
 
-    res.json({ totalCount, comments });
+    res.json({totalCount, comments});
   } catch (error) {
     console.error("Error fetching comments:", error);
-    res.status(500).json({ error: "Internal Server Error" });
+    res.status(500).json({error: "Internal Server Error"});
   }
 });
 

--- a/frontend/src/components/FilterTagRow/FilterTagSection.tsx
+++ b/frontend/src/components/FilterTagRow/FilterTagSection.tsx
@@ -1,0 +1,50 @@
+import {Badge, MantineColor, Text, useMantineTheme} from "@mantine/core";
+import React from 'react';
+import {IoMdClose} from "react-icons/io";
+
+interface FilterTagSectionProps {
+  sectionLabel: string;
+  tagList: string[];
+  selectedTagList: string[]
+  handleSelectTag: (tag: string) => void;
+  mapTagToLabel: Record<string, string>;
+  mapTagToBadgeColor?: Record<string, MantineColor>;
+}
+
+const FilterTagSection = ({
+                            sectionLabel,
+                            tagList,
+                            selectedTagList,
+                            handleSelectTag,
+                            mapTagToLabel,
+                            mapTagToBadgeColor
+                          }: FilterTagSectionProps) => {
+  const theme = useMantineTheme();
+
+  return (
+    <div className={`flex items-center flex-wrap gap-1`}>
+      <Text
+        c="dimmed"
+      >
+        {sectionLabel}
+      </Text>
+      {tagList.map((tag, i) => {
+        const selected = selectedTagList.includes(tag);
+        const selectedColor: MantineColor = (mapTagToBadgeColor && mapTagToBadgeColor[tag]) || theme.colors.blue[6];
+        return (
+          <Badge
+            key={i}
+            className="cursor-pointer hover:bg-slate-600"
+            color={selected ? selectedColor : theme.colors.gray[6]}
+            onClick={() => handleSelectTag(tag)}
+            rightSection={selected && <IoMdClose size={16}/>}
+          >
+            {mapTagToLabel[tag]}
+          </Badge>
+        );
+      })}
+    </div>
+  );
+};
+
+export default FilterTagSection;

--- a/frontend/src/components/FilterTagRow/index.ts
+++ b/frontend/src/components/FilterTagRow/index.ts
@@ -1,0 +1,1 @@
+export * from './FilterTagSection.tsx'

--- a/frontend/src/hooks/useCommentCategoryBadgeColor.ts
+++ b/frontend/src/hooks/useCommentCategoryBadgeColor.ts
@@ -1,0 +1,12 @@
+import {CommentCategory} from "@/typings/CommentTypes.ts";
+import {MantineColor, MantineTheme} from "@mantine/core";
+
+export const useCommentCategoryBadgeColor = (theme:MantineTheme) => {
+    const mapCommentCategoryToBadgeColor: Record<CommentCategory, MantineColor>  = {
+        [CommentCategory.SERIOUS_QUESTION]: theme.colors.violet[6],
+        [CommentCategory.VENT]: theme.colors.red[6],
+        [CommentCategory.ADVICE]: theme.colors.green[6],
+        [CommentCategory.HAPPY]: theme.colors.pink[6],
+    };
+    return {mapCommentCategoryToBadgeColor}
+}

--- a/frontend/src/hooks/useFilterTagSection.ts
+++ b/frontend/src/hooks/useFilterTagSection.ts
@@ -1,0 +1,25 @@
+import {useCallback, useState} from "react";
+
+export const useFilterTagSection = ({limitOneSelection}: {
+  limitOneSelection: boolean
+}) => {
+  const [selectedTagList, setSelectedTags] = useState<
+    string[]
+  >([]);
+
+  const handleSelectTag = useCallback((tag: string) => {
+    if (limitOneSelection) {
+      setSelectedTags(previousTags => previousTags.includes(tag) ? [] : [tag]);
+    } else {
+      setSelectedTags((previousTags) => {
+        if (previousTags.includes(tag)) {
+          return previousTags.filter((prevTag) => prevTag !== tag);
+        } else {
+          return [...previousTags, tag];
+        }
+      });
+    }
+  }, [limitOneSelection]);
+
+  return {selectedTagList, handleSelectTag};
+};

--- a/frontend/src/pages/listPages/Chat/Chat.tsx
+++ b/frontend/src/pages/listPages/Chat/Chat.tsx
@@ -1,9 +1,24 @@
-import { APP_NAME } from "@/constants";
+import FilterTagSection from "@/components/FilterTagRow/FilterTagSection.tsx";
+import {APP_NAME} from "@/constants";
+import {
+	useCommentCategoryBadgeColor
+} from "@/hooks/useCommentCategoryBadgeColor.ts";
+import {useFilterTagSection} from "@/hooks/useFilterTagSection.ts";
 import ChatTable from "@/tables/ChatTable/ChatTable";
-import { Text, Title } from "@mantine/core";
-import { Helmet } from "react-helmet";
+import {
+	CommentCategory,
+	mapCommentCategoryToLabel
+} from "@/typings/CommentTypes";
+import {Text, Title, useMantineTheme} from "@mantine/core";
+import {Helmet} from "react-helmet";
 
-export default () => {
+const Chat = () => {
+  const theme = useMantineTheme();
+  const {mapCommentCategoryToBadgeColor} = useCommentCategoryBadgeColor(theme);
+  const {
+    selectedTagList,
+    handleSelectTag
+  } = useFilterTagSection({limitOneSelection: false})
   return (
     <>
       <Helmet>
@@ -13,21 +28,30 @@ export default () => {
         <header>
           <Title
             order={2}
-            mb={{ base: "xs", md: "sm" }}
+            mb={{base: "xs", md: "sm"}}
             className="text-lg sm:text-xl md:text-2xl"
           >
             Main Chat
           </Title>
           <Text
             c="dimmed"
-            mb={{ base: "xs", md: "sm" }}
+            mb={{base: "xs", md: "sm"}}
             className="text-sm sm:text-base md:text-lg"
           >
             A place for general discussion.
           </Text>
+          <FilterTagSection sectionLabel={"Filters:"}
+                            tagList={Object.keys(CommentCategory)}
+                            selectedTagList={selectedTagList}
+                            handleSelectTag={handleSelectTag}
+                            mapTagToLabel={mapCommentCategoryToLabel}
+                            mapTagToBadgeColor={mapCommentCategoryToBadgeColor}/>
         </header>
-        <ChatTable />
+        <ChatTable
+          selectedCommentCategories={selectedTagList as CommentCategory[]}/>
       </div>
     </>
   );
 };
+
+export default Chat;

--- a/frontend/src/services/commentService.ts
+++ b/frontend/src/services/commentService.ts
@@ -1,4 +1,5 @@
 import apiClient from "@/apiClient";
+import {CommentCategory} from "@/typings/CommentTypes";
 
 const route = "/comment";
 
@@ -11,6 +12,7 @@ interface Comment {
   parentId: number | null;
   children: Comment[];
   // Add other comment-related properties here
+  category?: CommentCategory;
 }
 
 interface SearchCommentParams {
@@ -19,6 +21,7 @@ interface SearchCommentParams {
   main?: boolean;
   threadId?: number; // Assuming you want to filter by thread
   pageNum?: number;
+  selectedCommentCategories?: CommentCategory[];
 }
 
 interface SearchResponse {
@@ -27,29 +30,31 @@ interface SearchResponse {
 }
 
 const searchComment = async ({
-  pstp = false,
-  report = false,
-  main = false,
-  threadId,
-  pageNum = 1,
-}: SearchCommentParams): Promise<SearchResponse> => {
-  const { data } = await apiClient.post(`${route}/search`, {
+                               pstp = false,
+                               report = false,
+                               main = false,
+                               threadId,
+                               pageNum = 1,
+                               selectedCommentCategories = []
+                             }: SearchCommentParams): Promise<SearchResponse> => {
+  const {data} = await apiClient.post(`${route}/search`, {
     pstp,
     report,
     main,
     threadId,
     pageNum,
+    selectedCommentCategories
   });
   return data;
 };
 
 const createComment = async (formData: Partial<Comment>): Promise<Comment> => {
-  const { data } = await apiClient.post(route, formData);
+  const {data} = await apiClient.post(route, formData);
   return data;
 };
 
 const readComment = async (id: number): Promise<Comment> => {
-  const { data } = await apiClient.get(`${route}/${id}`);
+  const {data} = await apiClient.get(`${route}/${id}`);
   return data;
 };
 
@@ -57,7 +62,7 @@ const updateComment = async (
   id: number,
   formData: Partial<Comment>
 ): Promise<Comment> => {
-  const { data } = await apiClient.put(`${route}/${id}`, formData);
+  const {data} = await apiClient.put(`${route}/${id}`, formData);
   return data;
 };
 

--- a/frontend/src/tables/ChatTable/ChatTable.tsx
+++ b/frontend/src/tables/ChatTable/ChatTable.tsx
@@ -6,57 +6,60 @@ import { PAGE_SIZE } from "@/constants";
 import Controls from "@/components/Controls/Controls";
 import commentService from "@/services/commentService";
 import Comment from "@/components/Comment/Comment";
+import { CommentCategory } from "@/typings/CommentTypes";
 
 interface ChatTableProps {
-  className?: string;
+	className?: string;
+	selectedCommentCategories: CommentCategory[];
 }
 
-export default ({ className }: ChatTableProps) => {
-  const [pageNum, setPageNum] = useState(1);
+export default ({ className, selectedCommentCategories }: ChatTableProps) => {
+	const [pageNum, setPageNum] = useState(1);
 
-  const { data, error, isLoading } = useQuery({
-    queryKey: ["chat", pageNum],
-    queryFn: () => {
-      return commentService.searchComment({
-        pageNum,
-        main: true,
-      });
-    },
-  });
+	const { data, error, isLoading } = useQuery({
+		queryKey: ["chat", pageNum, JSON.stringify(selectedCommentCategories)],
+		queryFn: () => {
+			return commentService.searchComment({
+				pageNum,
+				main: true,
+				selectedCommentCategories,
+			});
+		},
+	});
 
-  const totalPages = useMemo(() => {
-    if (data) {
-      const totalCount = data?.totalCount || 0;
-      return Math.ceil(totalCount / PAGE_SIZE);
-    }
-  }, [data?.totalCount]);
+	const totalPages = useMemo(() => {
+		if (data) {
+			const totalCount = data?.totalCount || 0;
+			return Math.ceil(totalCount / PAGE_SIZE);
+		}
+	}, [data?.totalCount]);
 
-  return (
-    <div className={`${className}`}>
-      <Controls
-        noFilters
-        pageNum={pageNum}
-        setPageNum={setPageNum}
-        totalPages={totalPages}
-        shareUrl="/chat/add"
-        shareText="New Thread"
-      />
+	return (
+		<div className={`${className}`}>
+			<Controls
+				noFilters
+				pageNum={pageNum}
+				setPageNum={setPageNum}
+				totalPages={totalPages}
+				shareUrl="/chat/add"
+				shareText="New Thread"
+			/>
 
-      <div className={`mt-6`}>
-        {isLoading && (
-          <div className={`flex flex-col items-center`}>
-            <Loader color="blue" className={`mt-12`} />
-          </div>
-        )}
-        {data?.comments?.length > 0 && (
-          <div className={`flex flex-col gap-4`}>
-            {data.comments.map((item: any) => (
-              <Comment id={item.id} key={item.id} />
-            ))}
-          </div>
-        )}
-        {data?.comments && data.comments.length === 0 && <NoRecords />}
-      </div>
-    </div>
-  );
+			<div className={`mt-6`}>
+				{isLoading && (
+					<div className={`flex flex-col items-center`}>
+						<Loader color="blue" className={`mt-12`} />
+					</div>
+				)}
+				{data?.comments?.length > 0 && (
+					<div className={`flex flex-col gap-4`}>
+						{data.comments.map((item: any) => (
+							<Comment id={item.id} key={item.id} />
+						))}
+					</div>
+				)}
+				{data?.comments && data.comments.length === 0 && <NoRecords />}
+			</div>
+		</div>
+	);
 };

--- a/frontend/src/typings/CommentTypes.ts
+++ b/frontend/src/typings/CommentTypes.ts
@@ -1,0 +1,13 @@
+export enum CommentCategory {
+  SERIOUS_QUESTION = 'SERIOUS_QUESTION',
+  VENT = 'VENT',
+  ADVICE = 'ADVICE',
+  HAPPY = 'HAPPY',
+}
+
+export const mapCommentCategoryToLabel: Record<CommentCategory, string> = {
+  [CommentCategory.SERIOUS_QUESTION]: 'Serious Question',
+  [CommentCategory.ADVICE]: 'Advice',
+  [CommentCategory.VENT]: 'Vent',
+  [CommentCategory.HAPPY]: 'Happy',
+}


### PR DESCRIPTION
- Added README for setup and db migration instructions.
- Only show the category selection if adding a main chat thread.
- Added category selection on UI & server for add chat page (new thread)
- Refactored into filter tag section component and its hook
- Added proper mapping of comment category to text label
- Updated serious badge color
- Added ui & server-side filtering by comment category on main chat.