### PR TITLE
29: Add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,46 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: Bug
+assignees: ''
+
+---
+
+## Describe the bug
+
+A clear and concise description of what the bug is.
+
+## To Reproduce
+
+Steps to reproduce the behavior:
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+## Expected behavior
+
+A clear and concise description of what you expected to happen.
+
+## Screenshots
+
+If applicable, add screenshots to help explain your problem.
+
+## Desktop (please complete the following information):
+
+- OS: [e.g. iOS]
+- Browser [e.g. chrome, safari]
+- Version [e.g. 22]
+
+## Smartphone (please complete the following information):
+
+- Device: [e.g. iPhone6]
+- OS: [e.g. iOS8.1]
+- Browser [e.g. stock browser, safari]
+- Version [e.g. 22]
+
+## Additional context
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,21 @@
+---
+name: Default issue
+about: Explain the the details and requirements. Assign a label.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Motivation
+What is the goal? Why is this needed?
+
+## Requirements
+List the requirements that must be completed before this issue is closed.
+
+- [ ] Req 1
+- [ ] Req 2
+
+## Resources (code, documentation, links, images, gifs)
+
+Provide anything to help with understanding or development.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+## Description
+
+<!--- Describe your changes in detail.  -->
+
+## Steps to test
+
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+## Screenshots or recordings (if appropriate)
+
+## Checklist:
+
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+
+- [ ] My change requires a change to the documentation.
+- [ ] I have updated the documentation accordingly.
+- [ ] The project successfully builds on my local device.
+- [ ] I have added tests to cover my changes.
+- [ ] All new and existing tests passed locally.
+- [ ] Test coverage is at least 80%.
+- [ ] I have attached screenshots that prove the test-related checklist items.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adding github templates for creating new issues and PRs so they can have a standard format and hopefully be easier to read/understand.
This should only be possible to test when its merged to the main branch.
It's also possible that the repository owner/admin needs to go into their settings and turn it on. See [here](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository).

<!--- Describe your changes in detail.  -->

## Steps to test

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots or recordings (if appropriate)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] The project successfully builds on my local device.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed locally.
- [ ] Test coverage is at least 80%.
- [ ] I have attached screenshots that prove the test-related checklist items.
